### PR TITLE
Removal of Collections reference to User

### DIFF
--- a/models/user.js
+++ b/models/user.js
@@ -12,7 +12,6 @@ const userSchema = new Schema({
     firstName: {type: String},
     lastName: {type: String},
     email: {type: String, unique: true, required: true},
-    collectionId: {type: Schema.Types.ObjectId, ref: 'Collection'}
 }, {timestamps: true})
 
 const User = mongoose.model('User', userSchema);


### PR DESCRIPTION
Removing the reference of Collections to the user the better path. If we had users hold information about the collection, we would need to worry about syncing the User data any time we make changes/updates to the Collection.

If we kept User.collection available, and added a collection -> we need to update both Collection and User.